### PR TITLE
Corrects outdated header example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Example with color:
 
 ### Return a specific header
 
-    dummyhttp -b "Hello World" -H application/json
+    dummyhttp -b '{"Hello": "World"}' -h "content-type:application/json"
     curl localhost:8080
     # < HTTP/1.1 200 OK
     # < content-length: 10

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ Example with color:
     dummyhttp -b '{"Hello": "World"}' -h "content-type:application/json"
     curl localhost:8080
     # < HTTP/1.1 200 OK
-    # < content-length: 10
+    # < content-length: 19
     # < content-type: application/json
-    # < date: Thu, 14 Jun 2018 11:10:14 GMT
+    # < date: Fri, 29 Jul 2022 11:07:53 GMT
     # <
-    # Hello World
+    # {"Hello": "World"}
 
 ## How to install
 


### PR DESCRIPTION
The README example for setting a custom header was outdated.