### PR TITLE
Added functionality to delay response by specified time

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -52,6 +52,10 @@ pub struct Args {
     )]
     pub interface: IpAddr,
 
+    /// Delay in milliseconds before sending the response in milliseconds
+    #[arg(short, long, default_value = "0")]
+    pub delay: u64,
+
     /// Generate completion file for a shell
     #[arg(long = "print-completions", value_name = "shell")]
     pub print_completions: Option<clap_complete::Shell>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ async fn dummy_response(_uri: Uri, Extension(args): Extension<Args>) -> impl Int
     tera.register_function("lorem", template_lorem);
     let rendered_body = tera.render_str(&args.body, &tera::Context::new()).unwrap();
 
-    
+    // Delay response.
     sleep(Duration::from_millis(args.delay)).await;
 
     (status_code, headers, rendered_body)

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use colored::*;
 use colored_json::ToColoredJson;
 use hyper::{header::CONTENT_TYPE, HeaderMap};
 use inflector::Inflector;
+use tokio::time::{sleep, Duration};
 
 use crate::args::Args;
 
@@ -59,6 +60,10 @@ async fn dummy_response(_uri: Uri, Extension(args): Extension<Args>) -> impl Int
     tera.register_function("uuid", template_uuid);
     tera.register_function("lorem", template_lorem);
     let rendered_body = tera.render_str(&args.body, &tera::Context::new()).unwrap();
+
+    
+    sleep(Duration::from_millis(args.delay)).await;
+
     (status_code, headers, rendered_body)
 }
 

--- a/tests/requests.rs
+++ b/tests/requests.rs
@@ -121,3 +121,28 @@ fn returns_custom_headers(method: Method) -> Result<(), Error> {
 
     Ok(())
 }
+
+/// Setting a custom delay will delay the response making it at least that long.
+#[rstest(
+    method,
+    case::get(Method::GET),
+    case::post(Method::POST),
+    case::put(Method::PUT),
+    case::delete(Method::DELETE),
+    case::options(Method::OPTIONS),
+    case::patch(Method::PATCH),
+)]
+fn returns_custom_delay(method: Method) -> Result<(), Error> {
+    let dh = DummyhttpProcess::new(vec!["-d", "1000"])?;
+
+    let client = Client::new();
+    let start = std::time::Instant::now();
+    let resp = client.request(method, &dh.url).send()?;
+    let elapsed = start.elapsed();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(elapsed >= std::time::Duration::from_millis(1000));
+    assert_eq!(resp.text()?, "dummyhttp");
+
+    Ok(())
+}


### PR DESCRIPTION
Using `-d` or `--delay` it is now possible to add delay to response, which is especially useful for me personally when testing webhooks system.