### PR TITLE
Install rustfmt in toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        components: rustfmt
 
       - name: cargo build
         run: cargo build


### PR DESCRIPTION
This used to just work but now we somehow have to install it.