### PR TITLE
tests: fix test flakiness by avoiding localhost and adding port retry

### DIFF
--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -22,7 +22,6 @@ impl Drop for DummyhttpProcess {
     }
 }
 
-#[allow(dead_code)]
 impl DummyhttpProcess {
     /// Get a Dummyhttp instance on a free port.
     pub fn new<I, S>(args: I) -> Result<Self, Error>
@@ -30,32 +29,53 @@ impl DummyhttpProcess {
         I: IntoIterator<Item = S> + Clone + std::fmt::Debug,
         S: AsRef<OsStr> + PartialEq + From<&'static str>,
     {
-        let port = free_local_port()
-            .expect("Couldn't find a free local port")
-            .to_string();
+        let mut last_err = None;
+        for _ in 0..3 {
+            let port = free_local_port()
+                .expect("Couldn't find a free local port")
+                .to_string();
 
-        let child = Command::cargo_bin("dummyhttp")?
-            .arg("-p")
-            .arg(&port)
-            .args(args.clone())
-            .stdout(Stdio::piped())
-            .spawn()?;
+            let mut child = Command::cargo_bin("dummyhttp")?
+                .arg("-p")
+                .arg(&port)
+                .args(args.clone())
+                .stdout(Stdio::piped())
+                .spawn()?;
 
-        // Wait a max of 1s for the port to become available.
-        let start_wait = Instant::now();
-        while start_wait.elapsed().as_secs() < 1
-            && !is_port_reachable(format!("localhost:{}", port))
-        {
-            sleep(Duration::from_millis(100));
+            // Wait a max of 1s for the port to become available.
+            let start_wait = Instant::now();
+            let mut reachable = false;
+            while start_wait.elapsed().as_secs() < 1 {
+                if is_port_reachable(format!("127.0.0.1:{}", port)) {
+                    reachable = true;
+                    break;
+                }
+                // If the child exited early (e.g. port bind failure), stop waiting.
+                if let Ok(Some(status)) = child.try_wait() {
+                    last_err = Some(format!("child exited early with status: {}", status));
+                    break;
+                }
+                sleep(Duration::from_millis(50));
+            }
+
+            if reachable {
+                let proto = if args.clone().into_iter().any(|x| x == "--tls-cert".into()) {
+                    "https".to_string()
+                } else {
+                    "http".to_string()
+                };
+                let url = format!("{proto}://127.0.0.1:{port}", proto = proto, port = port);
+
+                return Ok(Self { child, url });
+            }
+
+            let _ = child.kill();
         }
 
-        let proto = if args.into_iter().any(|x| x == "--tls-cert".into()) {
-            "https".to_string()
-        } else {
-            "http".to_string()
-        };
-        let url = format!("{proto}://localhost:{port}", proto = proto, port = port);
-
-        Ok(Self { child, url })
+        Err(format!(
+            "Failed to start dummyhttp after 3 attempts. Last error: {:?}",
+            last_err
+        )
+        .into())
     }
 }


### PR DESCRIPTION
The flakiness came up during nix package upgrade https://github.com/NixOS/nixpkgs/pull/513622#issuecomment-4487796929

AI disclosure: Used antigravity cli to find the flaky test and create a patch.

1. Host/DNS Resolution Flakiness ( localhost  vs  127.0.0.1 ): The tests previously attempted to verify port reachability and perform test requests using  localhost . In sandboxed build environments (such as the Nix sandbox), hostname resolution for  localhost  can
  be unreliable or resolve to the IPv6 loopback address ( ::1 ) first. Because  dummyhttp  binds to  0.0.0.0  (IPv4-only by default), connecting via IPv6 fails or times out.
  2. Parallel Port Allocation Race Conditions: The test suite uses the  port_check  crate to query for a free port, which it then closes before starting the  dummyhttp  process. Since tests run in parallel, multiple tests could check for a free port, get the same port
  number, and cause  dummyhttp  to fail to bind on startup. Additionally, the startup loop would wait for the full timeout (1 second) instead of immediately failing-fast if the child process exited early.